### PR TITLE
Grpc metadata

### DIFF
--- a/proto/grpc-bus.proto
+++ b/proto/grpc-bus.proto
@@ -46,9 +46,16 @@ message GBReleaseService {
   int32 service_id = 1;
 }
 
+message GBMetadataValues {
+  repeated string values = 1;
+}
+
 message GBCallInfo {
   string method_id = 1;
   bytes bin_argument = 2;
+  // Meta is a map from string to []string
+  // e.g: https://godoc.org/google.golang.org/grpc/metadata#MD
+  map<string, GBMetadataValues> metadata = 3;
 }
 
 // Create a call

--- a/src/client/call.ts
+++ b/src/client/call.ts
@@ -35,6 +35,7 @@ export class Call implements ICallHandle {
               public clientServiceId: number,
               private info: IGBCallInfo,
               private callMeta: any,
+              private metadata: any,
               private callback: (error?: any, response?: any) => void,
               private send: (message: IGBClientMessage) => void) {
     this.requestBuilder = callMeta.resolvedRequestType.build();

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -149,17 +149,20 @@ export class Service {
     // lowercase first letter
     let methodName = methodMeta.name.charAt(0).toLowerCase() + methodMeta.name.slice(1);
     this.handle[methodName] = (argument?: any,
+                               metadata?: any,
                                callback?: (error?: any, response?: any) => void) => {
-      if (typeof argument === 'function' && !callback) {
+      console.log("GBClient.service.buildStubMethod ... in handler", argument, metadata, callback);
+      if (typeof argument === 'function' && !callback && !metadata) {
         callback = argument;
         argument = undefined;
       }
-      return this.startCall(methodMeta, argument, callback);
+      return this.startCall(methodMeta, argument, metadata, callback);
     };
   }
 
   private startCall(methodMeta: any,
                     argument?: any,
+                    metadata?: any,
                     callback?: (error?: any, response?: any) => void): ICallHandle {
     let callId = this.callIdCounter++;
     let args: any;
@@ -167,10 +170,13 @@ export class Service {
     if (argument) {
       args = requestBuilder.encode(argument);
     }
+    //SJ: define GBCallInfo here in client.service.startCall() ... this seems to be for non streaming calls
     let info: IGBCallInfo = {
       method_id: methodMeta.name,
       bin_argument: args,
+      metadata: metadata,
     };
+    console.log("GBCLIENT: constructed IGBCallInfo:", info);
     if (methodMeta.requestStream && argument) {
       throw new Error('Argument should not be specified for a request stream.');
     }
@@ -183,7 +189,7 @@ export class Service {
     if (!methodMeta.responseStream && !callback) {
       throw new Error('Callback should be specified for a non-streaming response.');
     }
-    let call = new Call(callId, this.clientId, info, methodMeta, callback, this.send);
+    let call = new Call(callId, this.clientId, info, methodMeta, metadata, callback, this.send);
     this.calls[callId] = call;
     call.disposed.subscribe(() => {
       delete this.calls[callId];

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -155,6 +155,10 @@ export class Service {
         callback = argument;
         argument = undefined;
       }
+      if (typeof metadata === 'function' && !callback) {
+        callback = metadata;
+        metadata = undefined;
+      }
       return this.startCall(methodMeta, argument, metadata, callback);
     };
   }

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -151,7 +151,6 @@ export class Service {
     this.handle[methodName] = (argument?: any,
                                metadata?: any,
                                callback?: (error?: any, response?: any) => void) => {
-      console.log("GBClient.service.buildStubMethod ... in handler", argument, metadata, callback);
       if (typeof argument === 'function' && !callback && !metadata) {
         callback = argument;
         argument = undefined;
@@ -170,13 +169,11 @@ export class Service {
     if (argument) {
       args = requestBuilder.encode(argument);
     }
-    //SJ: define GBCallInfo here in client.service.startCall() ... this seems to be for non streaming calls
     let info: IGBCallInfo = {
       method_id: methodMeta.name,
       bin_argument: args,
       metadata: metadata,
     };
-    console.log("GBCLIENT: constructed IGBCallInfo:", info);
     if (methodMeta.requestStream && argument) {
       throw new Error('Argument should not be specified for a request stream.');
     }

--- a/src/mock/definitions.ts
+++ b/src/mock/definitions.ts
@@ -7,6 +7,7 @@ export const PROTO_DEFINITIONS = {
     "messages": [
         {
             "name": "HelloRequest",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -14,11 +15,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "name",
                     "id": 1
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "HelloReply",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -26,20 +27,19 @@ export const PROTO_DEFINITIONS = {
                     "name": "message",
                     "id": 1
                 }
-            ],
-            "syntax": "proto3"
+            ]
         }
     ],
     "enums": [
         {
             "name": "EDummyEnum",
+            "syntax": "proto3",
             "values": [
                 {
                     "name": "DUMMY",
                     "id": 0
                 }
-            ],
-            "syntax": "proto3"
+            ]
         }
     ],
     "services": [

--- a/src/proto/definitions.ts
+++ b/src/proto/definitions.ts
@@ -7,6 +7,7 @@ export const PROTO_DEFINITIONS = {
     "messages": [
         {
             "name": "GBClientMessage",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -38,11 +39,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "call_send",
                     "id": 5
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBServerMessage",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -74,11 +75,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "call_ended",
                     "id": 5
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBServiceInfo",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -92,11 +93,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_id",
                     "id": 2
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBCreateService",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -110,11 +111,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_info",
                     "id": 2
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBReleaseService",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -122,11 +123,23 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_id",
                     "id": 1
                 }
-            ],
-            "syntax": "proto3"
+            ]
+        },
+        {
+            "name": "GBMetadataValues",
+            "syntax": "proto3",
+            "fields": [
+                {
+                    "rule": "repeated",
+                    "type": "string",
+                    "name": "values",
+                    "id": 1
+                }
+            ]
         },
         {
             "name": "GBCallInfo",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -139,12 +152,19 @@ export const PROTO_DEFINITIONS = {
                     "type": "bytes",
                     "name": "bin_argument",
                     "id": 2
+                },
+                {
+                    "rule": "map",
+                    "type": "GBMetadataValues",
+                    "keytype": "string",
+                    "name": "metadata",
+                    "id": 3
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBCreateCall",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -164,11 +184,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "info",
                     "id": 3
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBCallEnded",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -182,11 +202,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_id",
                     "id": 2
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBEndCall",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -200,11 +220,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_id",
                     "id": 2
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBSendCall",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -230,11 +250,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "is_end",
                     "id": 4
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBCreateServiceResult",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -255,10 +275,10 @@ export const PROTO_DEFINITIONS = {
                     "id": 3
                 }
             ],
-            "syntax": "proto3",
             "enums": [
                 {
                     "name": "ECreateServiceResult",
+                    "syntax": "proto3",
                     "values": [
                         {
                             "name": "SUCCESS",
@@ -272,13 +292,13 @@ export const PROTO_DEFINITIONS = {
                             "name": "GRPC_ERROR",
                             "id": 2
                         }
-                    ],
-                    "syntax": "proto3"
+                    ]
                 }
             ]
         },
         {
             "name": "GBReleaseServiceResult",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -286,11 +306,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_id",
                     "id": 1
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBCreateCallResult",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -317,10 +337,10 @@ export const PROTO_DEFINITIONS = {
                     "id": 3
                 }
             ],
-            "syntax": "proto3",
             "enums": [
                 {
                     "name": "ECreateCallResult",
+                    "syntax": "proto3",
                     "values": [
                         {
                             "name": "SUCCESS",
@@ -334,13 +354,13 @@ export const PROTO_DEFINITIONS = {
                             "name": "GRPC_ERROR",
                             "id": 2
                         }
-                    ],
-                    "syntax": "proto3"
+                    ]
                 }
             ]
         },
         {
             "name": "GBCallEvent",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -372,11 +392,11 @@ export const PROTO_DEFINITIONS = {
                     "name": "bin_data",
                     "id": 5
                 }
-            ],
-            "syntax": "proto3"
+            ]
         },
         {
             "name": "GBCallEnd",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -390,8 +410,7 @@ export const PROTO_DEFINITIONS = {
                     "name": "service_id",
                     "id": 2
                 }
-            ],
-            "syntax": "proto3"
+            ]
         }
     ],
     "isNamespace": true

--- a/src/proto/interfaces.ts
+++ b/src/proto/interfaces.ts
@@ -28,9 +28,14 @@ export interface IGBReleaseService {
   service_id?: number;
 }
 
+export interface IGBMetadataValues {
+  values: string[];
+}
+
 export interface IGBCallInfo {
   method_id?: string;
   bin_argument?: any;
+  metadata: { [key: string]: IGBMetadataValues };
 }
 
 export interface IGBCreateCall {

--- a/src/server/call.ts
+++ b/src/server/call.ts
@@ -64,6 +64,8 @@ export class Call {
       }
       let metadata = new this.grpc.Metadata();
       for(let key in this.callInfo.metadata.map) {
+        // metadata is decoded into a funny structure, but we can access 
+        // what we need under the '.map' field
         let metadataValues = this.callInfo.metadata.map[key].value.values;
         if (metadataValues) {
           for(let i=0; i < metadataValues.length; i++) {

--- a/src/server/call.ts
+++ b/src/server/call.ts
@@ -20,7 +20,8 @@ export class Call {
                      private clientId: number,
                      private clientServiceId: number,
                      private callInfo: IGBCallInfo,
-                     private send: (msg: IGBServerMessage) => void) {
+                     private send: (msg: IGBServerMessage) => void,
+                     private grpc: any) {
   }
 
   public initCall() {
@@ -61,7 +62,10 @@ export class Call {
                         ' requires an argument object of type ' +
                         rpcMeta.requestName + '.');
       }
-      this.service.stub[camelMethod](args, (error: any, response: any) => {
+
+      let dummyMeta = new this.grpc.Metadata();
+      dummyMeta.add('whoami', 'thewalrus');
+      this.service.stub[camelMethod](args, dummyMeta, (error: any, response: any) => {
         this.handleCallCallback(error, response);
       });
     }

--- a/src/server/call.ts
+++ b/src/server/call.ts
@@ -28,7 +28,6 @@ export class Call {
     if (!this.callInfo || !this.callInfo.method_id) {
       throw new Error('Call info, method ID must be given');
     }
-    console.log("in server call initCall(), callInfo:", this.callInfo);
     let args: any = this.callInfo.bin_argument;
     let rpcMeta = this.service.lookupMethod(this.callInfo.method_id);
     if (!rpcMeta) {
@@ -63,25 +62,15 @@ export class Call {
                         ' requires an argument object of type ' +
                         rpcMeta.requestName + '.');
       }
-      /*
-      let dummyMeta = new this.grpc.Metadata();
-      dummyMeta.add('whoami', 'thewalrus');
-      dummyMeta.add('whoami', 'googoogajoob');
-        */
-        console.log("GBSERVER.call.initCall() ... going to construct metadata from callinfo:", this.callInfo);
-        console.log("metadata:", this.callInfo.metadata.map);
       let metadata = new this.grpc.Metadata();
       for(let key in this.callInfo.metadata.map) {
-        console.log("I have key:", key);
         let metadataValues = this.callInfo.metadata.map[key].value.values;
-        console.log("GBSERVER.call.initcall() metadata values:", metadataValues);
         if (metadataValues) {
           for(let i=0; i < metadataValues.length; i++) {
             metadata.add(key, metadataValues[i]);
           }
         }
       }
-      console.log("GBSERVER.call.initCall() ... constructed metadata:", metadata);
       this.service.stub[camelMethod](args, metadata, (error: any, response: any) => {
         this.handleCallCallback(error, response);
       });

--- a/src/server/call.ts
+++ b/src/server/call.ts
@@ -28,6 +28,7 @@ export class Call {
     if (!this.callInfo || !this.callInfo.method_id) {
       throw new Error('Call info, method ID must be given');
     }
+    console.log("in server call initCall(), callInfo:", this.callInfo);
     let args: any = this.callInfo.bin_argument;
     let rpcMeta = this.service.lookupMethod(this.callInfo.method_id);
     if (!rpcMeta) {
@@ -62,10 +63,26 @@ export class Call {
                         ' requires an argument object of type ' +
                         rpcMeta.requestName + '.');
       }
-
+      /*
       let dummyMeta = new this.grpc.Metadata();
       dummyMeta.add('whoami', 'thewalrus');
-      this.service.stub[camelMethod](args, dummyMeta, (error: any, response: any) => {
+      dummyMeta.add('whoami', 'googoogajoob');
+        */
+        console.log("GBSERVER.call.initCall() ... going to construct metadata from callinfo:", this.callInfo);
+        console.log("metadata:", this.callInfo.metadata.map);
+      let metadata = new this.grpc.Metadata();
+      for(let key in this.callInfo.metadata.map) {
+        console.log("I have key:", key);
+        let metadataValues = this.callInfo.metadata.map[key].value.values;
+        console.log("GBSERVER.call.initcall() metadata values:", metadataValues);
+        if (metadataValues) {
+          for(let i=0; i < metadataValues.length; i++) {
+            metadata.add(key, metadataValues[i]);
+          }
+        }
+      }
+      console.log("GBSERVER.call.initCall() ... constructed metadata:", metadata);
+      this.service.stub[camelMethod](args, metadata, (error: any, response: any) => {
         this.handleCallCallback(error, response);
       });
     }

--- a/src/server/call_store.ts
+++ b/src/server/call_store.ts
@@ -24,6 +24,7 @@ export class CallStore {
       service_id: msg.service_id,
       result: 0,
     };
+    console.log("in server call_store initCall", msg);
     if (typeof msg.call_id !== 'number' || this.calls[msg.call_id]) {
       // todo: fix enums
       result.result = 1;
@@ -31,7 +32,9 @@ export class CallStore {
     } else {
       try {
         let callId = msg.call_id;
+        console.log("in server call_store ... creating call");
         let call = new Call(this.service, msg.call_id, msg.service_id, msg.info, this.send, this.grpc);
+        console.log("in server call_store ... created call");
         call.initCall();
         this.calls[msg.call_id] = call;
         call.disposed.subscribe(() => {

--- a/src/server/call_store.ts
+++ b/src/server/call_store.ts
@@ -24,7 +24,6 @@ export class CallStore {
       service_id: msg.service_id,
       result: 0,
     };
-    console.log("in server call_store initCall", msg);
     if (typeof msg.call_id !== 'number' || this.calls[msg.call_id]) {
       // todo: fix enums
       result.result = 1;
@@ -32,9 +31,7 @@ export class CallStore {
     } else {
       try {
         let callId = msg.call_id;
-        console.log("in server call_store ... creating call");
         let call = new Call(this.service, msg.call_id, msg.service_id, msg.info, this.send, this.grpc);
-        console.log("in server call_store ... created call");
         call.initCall();
         this.calls[msg.call_id] = call;
         call.disposed.subscribe(() => {

--- a/src/server/call_store.ts
+++ b/src/server/call_store.ts
@@ -14,7 +14,8 @@ export class CallStore {
 
   public constructor(private service: Service,
                      private clientId: number,
-                     private send: (msg: IGBServerMessage) => void) {
+                     private send: (msg: IGBServerMessage) => void,
+                     private grpc: any) {
   }
 
   public initCall(msg: IGBCreateCall) {
@@ -30,7 +31,7 @@ export class CallStore {
     } else {
       try {
         let callId = msg.call_id;
-        let call = new Call(this.service, msg.call_id, msg.service_id, msg.info, this.send);
+        let call = new Call(this.service, msg.call_id, msg.service_id, msg.info, this.send, this.grpc);
         call.initCall();
         this.calls[msg.call_id] = call;
         call.disposed.subscribe(() => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -28,6 +28,7 @@ export class Server {
   }
 
   public handleMessage(message: IGBClientMessage) {
+    console.log("in GB server handleMessage()", message);
     if (message.service_create) {
       this.handleServiceCreate(message.service_create);
     }
@@ -74,6 +75,7 @@ export class Server {
   }
 
   private handleServiceCreate(msg: IGBCreateService) {
+    console.log("in handleServiceCreate", msg);
     let serviceId = msg.service_id;
     let result: IGBCreateServiceResult = {
       service_id: msg.service_id,
@@ -95,6 +97,7 @@ export class Server {
         this.clientIdToService[serviceId] = new CallStore(serv, msg.service_id, this.send, this.grpc);
       } catch (e) {
         result.result = 2;
+        console.log("error creating service:", e.toString());
         result.error_details = e.toString();
       }
     }
@@ -118,6 +121,7 @@ export class Server {
   }
 
   private handleCallCreate(msg: IGBCreateCall) {
+    console.log("handling call create:", msg);
     let svc = this.clientIdToService[msg.service_id];
     if (!svc) {
       this.send({
@@ -130,6 +134,7 @@ export class Server {
       });
       return;
     }
+    console.log("svc.initCall");
     svc.initCall(msg);
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -28,7 +28,6 @@ export class Server {
   }
 
   public handleMessage(message: IGBClientMessage) {
-    console.log("in GB server handleMessage()", message);
     if (message.service_create) {
       this.handleServiceCreate(message.service_create);
     }
@@ -75,7 +74,6 @@ export class Server {
   }
 
   private handleServiceCreate(msg: IGBCreateService) {
-    console.log("in handleServiceCreate", msg);
     let serviceId = msg.service_id;
     let result: IGBCreateServiceResult = {
       service_id: msg.service_id,
@@ -97,7 +95,6 @@ export class Server {
         this.clientIdToService[serviceId] = new CallStore(serv, msg.service_id, this.send, this.grpc);
       } catch (e) {
         result.result = 2;
-        console.log("error creating service:", e.toString());
         result.error_details = e.toString();
       }
     }
@@ -121,7 +118,6 @@ export class Server {
   }
 
   private handleCallCreate(msg: IGBCreateCall) {
-    console.log("handling call create:", msg);
     let svc = this.clientIdToService[msg.service_id];
     if (!svc) {
       this.send({
@@ -134,7 +130,6 @@ export class Server {
       });
       return;
     }
-    console.log("svc.initCall");
     svc.initCall(msg);
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -92,7 +92,7 @@ export class Server {
         serv.disposed.subscribe(() => {
           this.releaseLocalService(serviceId, false);
         });
-        this.clientIdToService[serviceId] = new CallStore(serv, msg.service_id, this.send);
+        this.clientIdToService[serviceId] = new CallStore(serv, msg.service_id, this.send, this.grpc);
       } catch (e) {
         result.result = 2;
         result.error_details = e.toString();


### PR DESCRIPTION
Adds support for grpc's metadata sidechannel.

The client passes the map of values as part of the `GBCallInfo` object, which then gets translated into a proper `grpc.Metadata` object and sent to the upstream grpc server.